### PR TITLE
✨ Feat: 부스 조회 API 구현 (#3)

### DIFF
--- a/main/serializers.py
+++ b/main/serializers.py
@@ -1,0 +1,101 @@
+from rest_framework import serializers
+from .models import Booth, BoothImage
+
+
+class BoothImageSerializer(serializers.ModelSerializer):
+    image_url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = BoothImage
+        fields = ["order", "image_url"]
+
+    def get_image_url(self, obj):
+        if not obj.image:
+            return None
+        request = self.context.get("request")
+        return request.build_absolute_uri(obj.image.url) if request else obj.image.url
+
+
+class BoothListSerializer(serializers.ModelSerializer):
+    booth_id = serializers.IntegerField(source="id", read_only=True)
+    division_name = serializers.SerializerMethodField()
+    dates = serializers.SerializerMethodField()
+    location_name = serializers.CharField(source="location.name", read_only=True)
+    thumbnail_url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Booth
+        fields = [
+            "booth_id",
+            "name",
+            "booth_type",
+            "division_name",
+            "dates",
+            "location_name",
+            "loc_num",
+            "thumbnail_url",
+        ]
+
+    def get_division_name(self, obj):
+        return obj.division.name if obj.division else None
+
+    def get_dates(self, obj):
+        # day 필수 API라서 기본은 해당 day만 포함
+        return [str(obj.schedule.date)]
+
+    def get_thumbnail_url(self, obj):
+        first_img = obj.images.first()  # order=0
+        if not first_img or not first_img.image:
+            return None
+        request = self.context.get("request")
+        return request.build_absolute_uri(first_img.image.url) if request else first_img.image.url
+
+
+class BoothDetailSerializer(serializers.ModelSerializer):
+    booth_id = serializers.IntegerField(source="id", read_only=True)
+    division_name = serializers.SerializerMethodField()
+    dates = serializers.SerializerMethodField()
+    location_name = serializers.CharField(source="location.name", read_only=True)
+
+    event = serializers.SerializerMethodField()
+    instagram = serializers.SerializerMethodField()
+    images = BoothImageSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Booth
+        fields = [
+            "booth_id",
+            "name",
+            "booth_type",
+            "division_name",
+            "dates",
+            "location_name",
+            "loc_num",
+            "short_description",
+            "description",
+            "event",
+            "recruit_start",
+            "recruit_end",
+            "recruit_detail",
+            "instagram",
+            "images",
+        ]
+
+    def get_division_name(self, obj):
+        return obj.division.name if obj.division else None
+
+    def get_dates(self, obj):
+        return [str(obj.schedule.date)]
+
+    def get_event(self, obj):
+        if not obj.event:
+            return []
+        return [line.strip() for line in obj.event.splitlines() if line.strip()]
+
+    def get_instagram(self, obj):
+        if not obj.instagram_handle:
+            return None
+        handle = obj.instagram_handle.strip()
+        if not handle.startswith("@"):
+            handle = "@" + handle
+        return {"handle": handle, "url": f"https://instagram.com/{handle.lstrip('@')}"}

--- a/main/views.py
+++ b/main/views.py
@@ -1,3 +1,100 @@
+from collections import defaultdict
+from django.db.models import Q
 from django.shortcuts import render
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework import status
 
-# Create your views here.
+from .models import Booth
+from .serializers import BoothListSerializer, BoothDetailSerializer
+
+
+@api_view(["GET"])
+def booths_list(request):
+    day = request.GET.get("day")
+    if not day:
+        return Response(
+            {"code": "INVALID_DAY", "message": "day는 YYYY-MM-DD 형식의 필수 파라미터입니다."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    qs = Booth.objects.select_related("division", "location", "schedule").prefetch_related("images")
+    qs = qs.filter(schedule__date=day)
+
+    location_id = request.GET.get("location_id")
+    if location_id:
+        qs = qs.filter(location_id=location_id)
+
+    division_id = request.GET.get("division_id")
+    if division_id:
+        qs = qs.filter(division_id=division_id)
+
+    booth_type = request.GET.get("booth_type")
+    if booth_type:
+        qs = qs.filter(booth_type=booth_type)
+
+    q = request.GET.get("q")
+    if q:
+        qs = qs.filter(name__icontains=q)
+
+    # loc_num 오름차순 정렬
+    qs = qs.order_by("loc_num")
+
+    grouped = defaultdict(list)
+
+    for booth in qs:
+        key = (
+            booth.name,
+            booth.location_id,
+            booth.booth_type,
+            booth.division_id,
+        )
+        grouped[key].append(booth)
+
+    results = []
+
+    for booths in grouped.values():
+        # 현재 day 기준 row (대표 row)
+        representative = booths[0]
+
+        # 해당 name의 전체 날짜 조회
+        all_dates = (
+            Booth.objects.filter(
+                name=representative.name,
+                location=representative.location,
+                booth_type=representative.booth_type,
+                division=representative.division,
+            )
+            .values_list("schedule__date", flat=True)
+            .distinct()
+        )
+
+        dates = sorted([str(d) for d in all_dates])
+
+        serializer = BoothListSerializer(
+            representative, context={"request": request}
+        )
+        data = serializer.data
+        data["dates"] = dates
+
+        results.append(data)
+
+    return Response({"count": len(results), "results": results})
+
+
+@api_view(["GET"])
+def booth_detail(request, booth_id: int):
+    try:
+        booth = (
+            Booth.objects.select_related("division", "location", "schedule")
+            .prefetch_related("images")
+            .get(id=booth_id)
+        )
+    except Booth.DoesNotExist:
+        return Response(
+            {"code": "BOOTH_NOT_FOUND", "message": "해당 booth_id의 부스를 찾을 수 없습니다."},
+            status=status.HTTP_404_NOT_FOUND,
+        )
+
+    data = BoothDetailSerializer(booth, context={"request": request}).data
+    return Response(data)

--- a/project/urls.py
+++ b/project/urls.py
@@ -17,12 +17,14 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import path, include
-
 from django.conf import settings
 from django.conf.urls.static import static
+from main.views import booths_list, booth_detail
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/booths", booths_list),
+    path("api/booths/<int:booth_id>", booth_detail),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- #3 

### ✨️ 작업 내용

- GET /api/booths 구현 (day 필수, AND 필터, loc_num 정렬, q 부분검색, name 기준 그룹핑)
- GET /api/booths/{booth_id} 구현 (event 배열 변환, instagram 응답 구조, images 정렬)
- urls 라우팅 연결


### 📸 구현 결과
<img width="1182" height="1150" alt="image" src="https://github.com/user-attachments/assets/a790ac82-ab5f-4892-b46e-b9b560f14378" />

- 같은 `name` 그룹핑 처리하여 `dates` 양일 포함 OK
- 대표 `booth_id`는 현재 day row

<img width="1198" height="1176" alt="image" src="https://github.com/user-attachments/assets/b869fb30-4731-4877-964e-faace8324f57" />

- 부분일치 검색 OK

<img width="1278" height="1304" alt="image" src="https://github.com/user-attachments/assets/e80aaccc-4f44-4789-8622-cf741f579a63" />

- 상세 `images`가 여러 장 배열 OK
- `event` 배열 반환 OK
- `instagram` handle/url OK