### PR TITLE
[Feat] 공연 타임테이블 조회 API 구현 + 이미지 타임테이블 정책 반영

### DIFF
--- a/main/serializers.py
+++ b/main/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Booth, BoothImage
+from .models import Booth, BoothImage, TimeTable
 
 
 class BoothImageSerializer(serializers.ModelSerializer):
@@ -106,3 +106,46 @@ class BoothDetailSerializer(serializers.ModelSerializer):
         if not handle.startswith("@"):
             handle = "@" + handle
         return {"handle": handle, "url": f"https://instagram.com/{handle.lstrip('@')}"}
+    
+
+class TimeTableItemSerializer(serializers.ModelSerializer):
+    timetable_id = serializers.IntegerField(source="id", read_only=True)
+    image_url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = TimeTable
+        fields = [
+            "timetable_id",
+            "start_time",
+            "end_time",
+            "team_name",
+            "category",
+            "image_url",
+        ]
+
+    def get_image_url(self, obj):
+        """
+        우선순위 정리
+        1) Booth.name == TimeTable.team_name 매칭 후, BoothImage 첫 번째(order=0)
+        2) 없으면 TimeTable.image fallback
+        3) 없으면 null
+        """
+        request = self.context.get("request")
+
+        # 1) Booth 매칭되면: 활동사진 첫 번째 이미지
+        booth = (
+            Booth.objects.select_related("schedule")
+            .prefetch_related("images")
+            .filter(name=obj.team_name, schedule=obj.schedule)
+            .first()
+        )
+        if booth:
+            first_img = booth.images.first()
+            if first_img and first_img.image:
+                return request.build_absolute_uri(first_img.image.url) if request else first_img.image.url
+
+        # 2) fallback: TimeTable.image
+        if obj.image:
+            return request.build_absolute_uri(obj.image.url) if request else obj.image.url
+
+        return None

--- a/main/views.py
+++ b/main/views.py
@@ -5,8 +5,8 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework import status
 
-from .models import Booth
-from .serializers import BoothListSerializer, BoothDetailSerializer
+from .models import Booth, TimeTable, Location
+from .serializers import BoothListSerializer, BoothDetailSerializer, TimeTableItemSerializer
 
 
 @api_view(["GET"])
@@ -98,3 +98,40 @@ def booth_detail(request, booth_id: int):
 
     data = BoothDetailSerializer(booth, context={"request": request}).data
     return Response(data)
+
+
+@api_view(["GET"])
+def timetable_list(request):
+    day = request.GET.get("day")
+    if not day:
+        return Response(
+            {"code": "INVALID_DAY", "message": "day는 YYYY-MM-DD 형식의 필수 파라미터입니다."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # 공연은 만해광장만 -> location_name으로 고정 검색
+    try:
+        manhae = Location.objects.get(name="만해광장")
+    except Location.DoesNotExist:
+        return Response(
+            {"code": "LOCATION_NOT_FOUND", "message": "만해광장 Location 데이터가 없습니다."},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+    qs = (
+        TimeTable.objects.select_related("schedule", "location")
+        .filter(schedule__date=day, location=manhae)
+        .order_by("start_time")
+    )
+
+    items = TimeTableItemSerializer(qs, many=True, context={"request": request}).data
+
+    results = [
+        {
+            "location_id": manhae.id,
+            "location_name": manhae.name,
+            "items": items,
+        }
+    ]
+
+    return Response({"day": day, "results": results})

--- a/project/urls.py
+++ b/project/urls.py
@@ -19,12 +19,13 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
-from main.views import booths_list, booth_detail
+from main.views import booths_list, booth_detail, timetable_list
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/booths", booths_list),
     path("api/booths/<int:booth_id>", booth_detail),
+    path("api/timetable", timetable_list),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- #5 
- #7 

### ✨️ 작업 내용

- `GET /api/timetable` 공연 타임테이블 조회 API 구현
- 공연은 만해광장만 조회하도록 고정 처리
- start_time 오름차순 정렬 적용
- 이미지 정책 반영
    - 우선순위: Booth 활동사진(order=0) → TimeTable.image fallback → null
- 일정이 없는 날에도 results 구조 유지 (items: [])

### 💭 코멘트

- 공연만 하고 부스가 없는 팀을 고려하여 TimeTable.image를 fallback으로 유지했습니다.
- 현재는 team_name == Booth.name 매칭 방식으로 활동사진을 가져오고 있습니다.
- Location은 "만해광장" 이름 기반으로 조회하고 있습니다.
    - DB에 해당 row가 반드시 존재해야 합니다.

### 📸 구현 결과

<img width="1210" height="1306" alt="image" src="https://github.com/user-attachments/assets/6e6a1abf-df92-457f-b67a-3e6ad45f61e3" />

- 시간 오름차순 정렬 OK
- Booth 활동사진 우선 적용 OK
- fallback 이미지 정상 적용 OK

<img width="1224" height="732" alt="image" src="https://github.com/user-attachments/assets/a1507774-52be-4bbf-a1c6-58032d5eec13" />

- 일정 없는 날 items: [] 반환 OK
