### PR TITLE
[Fix] 부스 상세 dates를 전체 운영일로 반환

### DIFF
--- a/main/serializers.py
+++ b/main/serializers.py
@@ -92,7 +92,14 @@ class BoothDetailSerializer(serializers.ModelSerializer):
         return obj.division.name if obj.division else None
 
     def get_dates(self, obj):
-        return [str(obj.schedule.date)]
+        qs = Booth.objects.filter(
+            name=obj.name,
+            location=obj.location,
+            booth_type=obj.booth_type,
+            division=obj.division,
+        ).values_list("schedule__date", flat=True).distinct()
+
+        return sorted([str(d) for d in qs])
 
     def get_event(self, obj):
         if not obj.event:


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #9

### ✨️ 작업 내용

- 부스 상세 조회(/api/booths/{booth_id})에서 dates가 단일 날짜만 내려가던 문제 수정
- Booth(name + location + booth_type + division) 기준으로 전체 운영 날짜를 조회해 dates로 반환하도록 변경

### 📸 구현 결과

<img width="1222" height="656" alt="image" src="https://github.com/user-attachments/assets/8da87a95-efd1-4071-8866-b1461ac58b07" />

- 양일 운영 부스의 경우 전체 운영일(2개) 반환 OK