### PR TITLE
[Refactor] booths_list N+1 쿼리 제거 및 성능 최적화

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -18,6 +18,21 @@ def booths_list(request):
             status=status.HTTP_400_BAD_REQUEST,
         )
 
+    # 전체 부스 가져와서 날짜 dict 구성
+    all_booths = Booth.objects.select_related("schedule")
+
+    dates_dict = defaultdict(set)  # 부스별 전체 날짜 dict
+
+    for b in all_booths:
+        key = (
+            b.name,
+            b.location_id,
+            b.booth_type,
+            b.division_id,
+        )
+        dates_dict[key].add(str(b.schedule.date))
+
+    # day 필터
     qs = Booth.objects.select_related("division", "location", "schedule").prefetch_related("images")
     qs = qs.filter(schedule__date=day)
 
@@ -37,9 +52,9 @@ def booths_list(request):
     if q:
         qs = qs.filter(name__icontains=q)
 
-    # loc_num 오름차순 정렬
-    qs = qs.order_by("loc_num")
+    qs = qs.order_by("loc_num")  # loc_num 오름차순 정렬
 
+    # 카드 단위 그룹핑
     grouped = defaultdict(list)
 
     for booth in qs:
@@ -53,28 +68,18 @@ def booths_list(request):
 
     results = []
 
-    for booths in grouped.values():
-        # 현재 day 기준 row (대표 row)
-        representative = booths[0]
+    for key, booths in grouped.items():
+        # 대표 row: loc_num 최소
+        representative = min(booths, key=lambda b: b.loc_num)
 
-        # 해당 name의 전체 날짜 조회
-        all_dates = (
-            Booth.objects.filter(
-                name=representative.name,
-                location=representative.location,
-                booth_type=representative.booth_type,
-                division=representative.division,
-            )
-            .values_list("schedule__date", flat=True)
-            .distinct()
-        )
-
-        dates = sorted([str(d) for d in all_dates])
+        # 전체 운영 날짜 (위에서 만든 dict 사용)
+        dates = sorted(dates_dict.get(key, []))
 
         serializer = BoothListSerializer(
             representative, context={"request": request}
         )
         data = serializer.data
+
         data["dates"] = dates
 
         results.append(data)


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #11 

### ✨️ 작업 내용

- `/api/booths`에서 그룹별 dates 조회 시 발생하던 N+1 쿼리 제거
- 전체 부스 운영 날짜를 한 번에 조회 후 dict로 구성

### 💭 코멘트

- 쿼리 수가 그룹 수에 비례하던 구조를 개선해서 성능 최적화하였습니다.

### 📸 구현 결과

<img width="1224" height="1270" alt="image" src="https://github.com/user-attachments/assets/101ba846-0d57-4b4d-976a-e08e52461f62" />
