### PR TITLE
[Feat] 퀴즈 리스트 조회 API 구현

### DIFF
--- a/project/urls.py
+++ b/project/urls.py
@@ -20,12 +20,15 @@ from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
 from main.views import booths_list, booth_detail, timetable_list
+from quiz.views import QuizListView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/booths", booths_list),
     path("api/booths/<int:booth_id>", booth_detail),
     path("api/timetable", timetable_list),
+
+    path("api/quiz", QuizListView.as_view(), name="quiz-list"),
 ]
 
 if settings.DEBUG:

--- a/quiz/admin.py
+++ b/quiz/admin.py
@@ -1,3 +1,6 @@
 from django.contrib import admin
+from .models import *
 
-# Register your models here.
+
+admin.site.register(Quiz)
+admin.site.register(QuizOption)

--- a/quiz/models.py
+++ b/quiz/models.py
@@ -13,7 +13,7 @@ class Quiz(models.Model):
           ordering = ['order']
 
      def __str__(self):
-          return f"{self.order}번. {self.question}"
+          return f"Q{self.order}. {self.question}"
 
 
 class QuizOption(models.Model):
@@ -36,4 +36,4 @@ class QuizOption(models.Model):
           verbose_name_plural = "퀴즈 선택지들"
 
      def __str__(self):
-          return f"[{self.quiz.order}번 퀴즈] {self.answer} -> {self.division.name}"
+          return f"[Q{self.quiz.order}] {self.answer} -> {self.division.name}"

--- a/quiz/serializers.py
+++ b/quiz/serializers.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+from .models import *
+
+class QuizOptionSerializer(serializers.ModelSerializer) :
+     class Meta:
+          model = QuizOption
+          fields = ['id', 'answer', 'division']
+
+
+class QuizSerializer(serializers.ModelSerializer):
+     options = QuizOptionSerializer(many=True, read_only=True)
+
+     class Meta:
+          model = Quiz
+          fields = ['id', 'question', 'order', 'options']

--- a/quiz/urls.py
+++ b/quiz/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import QuizListView
+
+urlpatterns = [
+     path('', QuizListView.as_view(), name='quiz-list'), # /api/quiz/
+]

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -1,3 +1,12 @@
 from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from .models import *
+from .serializers import *
 
-# Create your views here.
+class QuizListView(APIView):
+     def get(self, request):
+          set = Quiz.objects.all().prefetch_related('options').order_by('order')
+          serializer = QuizSerializer(set, many=True)
+          return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #15

### ✨️ 작업 내용

- 퀴즈는 order 순
- 퀴즈별 선택지도 함께 리턴 
- 퀴즈 순서 및 분과 순서 데이터베이스는 노션 <시드데이터> 문서에 저장해 둠 

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과
<img width="1340" height="1328" alt="image" src="https://github.com/user-attachments/assets/39632823-3be0-4274-b4a7-a5e5eb22896a" />
<img width="1340" height="1328" alt="image" src="https://github.com/user-attachments/assets/39632823-3be0-4274-b4a7-a5e5eb22896a" />
