### PR TITLE
[Fix] 퀴즈 결과 분과 산정 방식 보강

### DIFF
--- a/quiz/views.py
+++ b/quiz/views.py
@@ -30,27 +30,58 @@ class QuizSubmitView(APIView) :
                     status=status.HTTP_400_BAD_REQUEST
                )
           
-          # 1. 가장 많이 선택된 분과 ID
-          counts = Counter(division_ids)
-          most_common_id = counts.most_common(1)[0][0]
+          # 0. 세팅
+          weights = [1, 1, 1, 2, 2, 3]
+          PRIORITY = [1, 2, 3, 4, 5, 6, 7, 8]
+          NEW_DIVISION_ID = 8
 
+          # 1. 점수 계산
+          scores = {}
+          for i in range(6) :
+               weight = weights[i]
+               div_id = division_ids[i]
+               point = 2 if div_id == NEW_DIVISION_ID else 1
+               plus = weight * point
+               scores[div_id] = scores.get(div_id, 0) + plus
+
+          # 2. 1차 결과
+          max_score = max(scores.values())
+          candidates = [div_id for div_id, score in scores.items() if score == max_score]
+
+          # 3. 타이브레이커
+          final_division_id = None
+
+          if len(candidates) == 1:
+               final_division_id = candidates[0]
+          else:
+               # 동점 시: Q6 -> Q1 순으로 사용자가 해당 문항에서 고른 분과가 후보군에 있는지 확인
+               for picked_id in reversed(division_ids[:6]):
+                    if picked_id in candidates:
+                         final_division_id = picked_id
+                         break
+               
+               # 4. 최후 안전장치: 고정 우선순위
+               if final_division_id is None:
+                    for p_id in PRIORITY:
+                         if p_id in candidates:
+                              final_division_id = p_id
+                              break
+
+
+          # 5. 결과 반환 + 부스 정보 리스트
           try:
-               # 2. 결과 분과 조회
-               target_division = Division.objects.get(id=most_common_id)
+               target_division = Division.objects.get(id=final_division_id)
                today_str = timezone.localtime(timezone.now()).strftime('%Y-%m-%d')
 
-               # 3. 해당 분과에 속하는 부스 리스트
+               # 내부 부스 조회 함수 호출 (기존 로직 유지)
+               from .views import booths_list 
                inner_request = request._request
-               
                qd = QueryDict(mutable=True)
-               qd.update({
-                    'division_id': str(target_division.id),
-                    'day': today_str
-               })
+               qd.update({'division_id': str(target_division.id), 'day': today_str})
                inner_request.GET = qd
+               
                booths_response = booths_list(inner_request)
 
-               # 3. 결과 반환
                return Response({
                     "recommended_division": {
                          "id": target_division.id,
@@ -60,4 +91,4 @@ class QuizSubmitView(APIView) :
                }, status=status.HTTP_200_OK)
 
           except Division.DoesNotExist:
-               return Response({"error": "존재하지 않는 분과 ID입니다."}, status=status.HTTP_404_NOT_FOUND)
+               return Response({"error": "산출된 분과 ID가 존재하지 않습니다."}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #22

### ✨️ 작업 내용
기존 최다 선택 분과를 결과로 보여주는 로직에서 이하 로직으로 변경

1. 점수 계산
- 기본 점수는 선택한 분과 +1
- **신규 분과 선택만 +2**로 보정
- 문항 가중치는 Q1~Q6 = **[1, 1, 1, 2, 2, 3]** 적용
    
    → 최종 점수 = (선택 점수) × (해당 문항 가중치)
    
2. 결과 선택
- 최고 점수 분과가 1개면 그대로 확정
- 동점이면 **Q6 → Q5 → Q4 → Q3 → Q2 → Q1** 순으로 확인해서,
    
    해당 문항에서 사용자가 선택한 분과가 동점 후보에 포함되면 그 분과로 확정
    
3. 최후 예외 처리
- 그래도 못 정하면 사전에 정한 고정 우선순위로 결정

### 📸 구현 결과

<img width="1383" height="981" alt="image" src="https://github.com/user-attachments/assets/a688ce02-ad1a-4d81-9367-daa860816272" />