### PR TITLE
[Fix] 퀴즈 결과 부스 날짜 양일 모두 반환하도록 수정

### DIFF
--- a/main/serializers.py
+++ b/main/serializers.py
@@ -46,6 +46,9 @@ class BoothListSerializer(serializers.ModelSerializer):
         return obj.division.name if obj.division else None
 
     def get_dates(self, obj):
+        if hasattr(obj, "merged_dates"):
+            return obj.merged_dates
+        
         # day 필수 API라서 기본은 해당 day만 포함
         return [str(obj.schedule.date)]
 

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from rest_framework import status
 from collections import Counter
 from django.http import QueryDict
+from collections import defaultdict
 
 from main.models import *
 from .models import *
@@ -76,14 +77,33 @@ class QuizSubmitView(APIView) :
                     .prefetch_related("images")\
                     .order_by("name", "loc_num")
                
-               # 동일한 이름의 부스가 여러 날짜에 걸쳐 있을 경우 1개만 표시
-               unique_booths = {}
+               grouped_booths = defaultdict(list)
+
+               # 같은 부스 기준으로 그룹화
                for b in booths_qs:
-                    if b.name not in unique_booths:
-                         unique_booths[b.name] = b
+                    key = (
+                         b.name,
+                    )
+                    grouped_booths[key].append(b)
+
+               final_booths = []
+
+               # 날짜 병합
+               for key, booth_list in grouped_booths.items():
+                    first_booth = booth_list[0]
+
+                    # 모든 날짜 + 정렬
+                    all_dates = sorted(
+                         [b.schedule.date for b in booth_list]
+                    )
+
+                    # date를 배열로 
+                    first_booth.merged_dates = all_dates
+
+                    final_booths.append(first_booth)
                
                serializer = BoothListSerializer(
-                    unique_booths.values(), 
+                    final_booths, 
                     many=True, 
                     context={"request": request}
                )


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #29

### ✨️ 작업 내용

퀴즈 결과 부스 날짜 양일 모두 반환하도록 수정

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

<img width="781" height="975" alt="image" src="https://github.com/user-attachments/assets/596c9459-dd33-46dc-b362-2035c9ceed0b" />
