### PR TITLE
[Fix] 부스리스트 has_detail 로직 수정

### DIFF
--- a/main/serializers.py
+++ b/main/serializers.py
@@ -39,7 +39,25 @@ class BoothListSerializer(serializers.ModelSerializer):
         ]
 
     def get_has_detail(self, obj):
-        return True
+
+        # 푸드트럭은 전부 true로 처리
+        if obj.booth_type == Booth.BoothType.FOODTRUCK:
+            return True
+
+        # 상세 관련 텍스트/기간/인스타/로고/이미지 중 하나라도 있으면 true로 처리
+        has_any_text = any([
+            bool(obj.short_description.strip()),
+            bool(obj.description.strip()),
+            bool(obj.event.strip()),
+            bool((obj.recruit_detail or "").strip()),
+            bool((obj.instagram_handle or "").strip()),
+        ])
+
+        has_recruit_date = bool(obj.recruit_start) or bool(obj.recruit_end)
+        has_logo = bool(obj.logo)
+        has_images = obj.images.exists()
+
+        return bool(has_any_text or has_recruit_date or has_logo or has_images)
 
     def get_logo_url(self, obj):
         if not obj.logo:


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #34 

### ✨️ 작업 내용

- `/api/booths` 카드리스트 응답의 has_detail 판별 로직 수정했습니다.
  - FOODTRUCK: 전부 true로 처리 (전부 상세 존재함)
  - CLUB: 상세 관련 데이터(소개/모집/이벤트/인스타/로고/활동사진/모집기간 등) 중 하나라도 있으면 true & 전부 비어있으면 false

### 💭 코멘트

- 미제출 동아리 row는 name/booth_type/loc_num/division/schedule/location만 존재하고 나머지 필드가 비어있어, has_detail=false로 내려가도록 했습니다.

### 📸 구현 결과

<img width="1230" height="904" alt="image" src="https://github.com/user-attachments/assets/f8e9466b-88ba-44c8-9ce3-ce6bfa8e3cb8" />
